### PR TITLE
HAL JSON Validations

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -2,7 +2,7 @@
 
 [file-type]
 
-command=bundle exec srb tc $(VIM_FILENAME)
+command=bundle exec srb tc $(VIM_FILEPATH)
 cwd=<root>
 output=quickfix
 errorformat=%f:%l:%m
@@ -10,7 +10,7 @@ save=1
 
 [file-fix]
 
-command=bundle exec rbprettier --write $(VIM_FILENAME)
+command=bundle exec rbprettier --write $(VIM_FILEPATH)
 cwd=<root>
 output=quickfix
 errorformat=%f:%l:%m

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sorbet-runtime'
 gem 'prettier'
 gem 'dry-events'
 gem 'dry-validation'
+gem 'ulid-ruby'
 
 group :test do
   gem 'minitest-matchers_vaccine'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'sorbet', group: 'development'
 gem 'sorbet-runtime'
 gem 'prettier'
 gem 'dry-events'
+gem 'dry-validation'
 
 group :test do
   gem 'minitest-matchers_vaccine'

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ gem 'ulid-ruby'
 group :test do
   gem 'minitest-matchers_vaccine'
   gem 'mocha'
+  gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.6)
+    dry-configurable (0.11.4)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4, >= 0.4.7)
+      dry-equalizer (~> 0.2)
+    dry-container (0.7.2)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.1, >= 0.1.3)
     dry-core (0.4.9)
       concurrent-ruby (~> 1.0)
     dry-equalizer (0.3.0)
@@ -9,6 +16,34 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4)
       dry-equalizer (~> 0.2)
+    dry-inflector (0.2.0)
+    dry-initializer (3.0.3)
+    dry-logic (1.0.6)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.2)
+      dry-equalizer (~> 0.2)
+    dry-schema (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.8, >= 0.8.3)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.0)
+      dry-types (~> 1.4)
+    dry-types (1.4.0)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.4, >= 0.4.4)
+      dry-equalizer (~> 0.3)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
+    dry-validation (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.5)
     hanami-api (0.1.0)
       hanami-router (~> 2.0.alpha)
     hanami-router (2.0.0.alpha2)
@@ -38,6 +73,7 @@ PLATFORMS
 
 DEPENDENCIES
   dry-events
+  dry-validation
   hanami-api (~> 0.1)
   minitest-matchers_vaccine
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,9 +44,9 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5)
-    hanami-api (0.1.0)
+    hanami-api (0.1.1)
       hanami-router (~> 2.0.alpha)
-    hanami-router (2.0.0.alpha2)
+    hanami-router (2.0.0.alpha3)
       mustermann (~> 1.0)
       mustermann-contrib (~> 1.0)
       rack (~> 2.0)
@@ -62,6 +62,8 @@ GEM
       mustermann (= 1.1.1)
     prettier (0.18.0)
     rack (2.2.2)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     ruby2_keywords (0.0.2)
     sorbet (0.5.5429)
       sorbet-static (= 0.5.5429)
@@ -79,6 +81,7 @@ DEPENDENCIES
   minitest-matchers_vaccine
   mocha
   prettier
+  rack-test
   sorbet
   sorbet-runtime
   ulid-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       sorbet-static (= 0.5.5429)
     sorbet-runtime (0.5.5429)
     sorbet-static (0.5.5429-universal-darwin-14)
+    ulid-ruby (1.0.0)
 
 PLATFORMS
   ruby
@@ -80,6 +81,7 @@ DEPENDENCIES
   prettier
   sorbet
   sorbet-runtime
+  ulid-ruby
 
 BUNDLED WITH
    2.1.4

--- a/app.rb
+++ b/app.rb
@@ -3,8 +3,11 @@
 
 require 'bundler/setup'
 require 'hanami/api'
+require 'ulid'
+require_relative './middlewares/body_params_validator'
 
 class App < Hanami::API
+  use BodyParamsValidator
   get '/' do
     200
   end
@@ -13,9 +16,11 @@ class App < Hanami::API
     scope 'v1' do
       post '/products' do
         publisher = ProductPublisher.new
-        publisher.publish('product.created', product: params)
+        id = ULID.generate
+        publisher.publish('product.created', product: params.merge(id: id))
 
         status(201)
+        headers['Location'] = "/api/v1/product/#{id}"
         json(params, 'application/hal+json')
       end
     end

--- a/app.rb
+++ b/app.rb
@@ -7,12 +7,12 @@ require 'ulid'
 require_relative './middlewares/body_params_validator'
 
 class App < Hanami::API
-  use BodyParamsValidator
   get '/' do
     200
   end
 
   scope 'api' do
+    use BodyParamsValidator
     scope 'v1' do
       post '/products' do
         publisher = ProductPublisher.new

--- a/app.rb
+++ b/app.rb
@@ -14,6 +14,16 @@ class App < Hanami::API
   scope 'api' do
     use BodyParamsValidator
     scope 'v1' do
+      get '/product/:id' do
+        publisher = ProductPublisher.new
+        repo = ProductRepository.new
+
+        product = repo.get(params[:id])
+        publisher.publish('product.requested', id: params[:id]) if product
+
+        json(product, 'application/hal+json')
+      end
+
       post '/products' do
         publisher = ProductPublisher.new
         id = ULID.generate

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,3 @@
 require_relative './app'
 
-App.run
+run App.new

--- a/middlewares/body_params_validator.rb
+++ b/middlewares/body_params_validator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+#
+# typed: true
+require_relative '../schemas/body_params'
+
+class BodyParamsValidator
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    req = Rack::Request.new(env)
+    return @app.call(env) unless req.post? || req.patch? || req.put?
+
+    check = links_present?(req.params)
+
+    return bad_request if check.errors.any?
+
+    @app.call(env)
+  end
+
+  private
+
+  def links_present?(params)
+    links_contract.call(params)
+  end
+
+  def links_contract
+    BodyParamsContract.new
+  end
+
+  def bad_request
+    [400, { 'Content-Type' => 'application/hal+json' }, {}]
+  end
+end

--- a/publishers/product_publisher.rb
+++ b/publishers/product_publisher.rb
@@ -8,6 +8,8 @@ class ProductPublisher < BasePublisher
   sig { void }
   def initialize
     publisher(:product_publisher)
+
     register_event('product.created')
+    register_event('product.requested')
   end
 end

--- a/repositories/product.rb
+++ b/repositories/product.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+#typed: strong
+PRODUCTS = [
+  {
+    id: '123ME',
+    name: 'Bilbo Baggins Bag-End',
+    description: 'A Hovel',
+    active: true
+  }
+]
+
+class ProductRepository
+  def get(id)
+    PRODUCTS.select { |product| product[:id] == id }.first.tap do |product|
+      product[:_links] = { self: { href: "/products/#{product[:id]}" } }
+    end
+  end
+end

--- a/schemas/base.rb
+++ b/schemas/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+#
+# typed: false
+require 'dry/validation'
+
+CreateSchema =
+  Dry::Schema.Params do
+    required(:attributes).hash
+  end

--- a/schemas/body_params.rb
+++ b/schemas/body_params.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+#
+# typed: false
+
+require 'dry/validation'
+require_relative './base'
+
+class BodyParamsContract < Dry::Validation::Contract
+  params(CreateSchema) {}
+end

--- a/schemas/product_create.rb
+++ b/schemas/product_create.rb
@@ -1,0 +1,12 @@
+require 'dry/validation'
+require_relative './base'
+
+class ProductCreateContract < Dry::Validation::Contract
+  params do
+    required(:attributes).hash do
+      required(:name).value(:string)
+      required(:description).value(:string)
+      required(:active).value(:boolean)
+    end
+  end
+end

--- a/test/request/body_params_test.rb
+++ b/test/request/body_params_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+#
+# typed: false
+
+require_relative '../spec_helper'
+
+class BodyParamsTest < RequestTest
+  let(:base_app) do
+    Class.new(Hanami::API) do
+      use BodyParamsValidator
+      post '/api/products' do
+        [201, { 'Content-Type' => 'application/hal+json' }, '']
+      end
+    end.new
+  end
+  let(:api) { Rack::MockRequest.new(base_app) }
+  let(:params) do
+    {
+      _links: {},
+      attributes: {
+        name: 'OldGregg', description: 'The Locke Monster', active: true
+      }
+    }
+  end
+  let(:missing_params) do
+    {
+      name: 'OldGregg', description: 'The Locke Monster', active: true
+    }
+  end
+
+  describe 'POST any resource' do
+    describe 'succeeds' do
+      it 'with a 201 due to the presence of attributes and resource keys' do
+        req = api.post '/api/products', params: params
+        _(req.status).must_equal 201
+      end
+    end
+    describe 'fails' do
+      it 'with a 400 due to missing params' do
+        req = api.post '/api/products', params: missing_params
+
+        _(req.status).must_equal 400
+      end
+    end
+  end
+end

--- a/test/request/product_create_test.rb
+++ b/test/request/product_create_test.rb
@@ -16,12 +16,12 @@ class ProductCreateTest < RequestTest
       let(:product_create_route) { '/api/v1/products' }
 
       it 'successfully sends a message to create a new product' do
-        req = app.post product_create_route, params: product_params
+        req = post product_create_route, product_params
         _(req.status).must_equal 201
       end
 
       it 'sends the location of the new object for retrieval' do
-        req = app.post product_create_route, params: product_params
+        req = post product_create_route, product_params
         _(req.headers['Location']).must_match %r{\/api\/v1\/product\/\S+}
       end
     end

--- a/test/request/product_create_test.rb
+++ b/test/request/product_create_test.rb
@@ -19,11 +19,10 @@ class ProductCreateTest < RequestTest
         req = app.post product_create_route, params: product_params
         _(req.status).must_equal 201
       end
-    end
 
-    describe 'failure' do
-      it 'responds with an error object' do
-        req = app.post product_create_route, params: {}
+      it 'sends the location of the new object for retrieval' do
+        req = app.post product_create_route, params: product_params
+        _(req.headers['Location']).must_match %r{\/api\/v1\/product\/\S+}
       end
     end
   end

--- a/test/request/product_create_test.rb
+++ b/test/request/product_create_test.rb
@@ -4,19 +4,27 @@
 require_relative '../spec_helper'
 
 class ProductCreateTest < RequestTest
-  describe "POST /api/v1/products" do
-    let(:product_params) do
-      {
-        name: 'OldGregg',
-        description: 'The Locke Monster',
-        active: 'true'
-      }
+  describe 'POST /api/v1/products' do
+    describe 'success' do
+      let(:product_params) do
+        {
+          attributes: {
+            name: 'OldGregg', description: 'The Locke Monster', active: true
+          }
+        }
+      end
+      let(:product_create_route) { '/api/v1/products' }
+
+      it 'successfully sends a message to create a new product' do
+        req = app.post product_create_route, params: product_params
+        _(req.status).must_equal 201
+      end
     end
 
-    subject { app.post '/api/v1/products', product_params }
-
-    it 'successfully sends a message to create a new product' do
-      _(subject.status).must_equal 201
+    describe 'failure' do
+      it 'responds with an error object' do
+        req = app.post product_create_route, params: {}
+      end
     end
   end
 end

--- a/test/request/product_get_test.rb
+++ b/test/request/product_get_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative '../spec_helper'
+
+class ProductGetTest < RequestTest
+  describe 'GET /api/v1/product/:id' do
+    describe 'success' do
+      let(:ulid) { '123ME' }
+      let(:product_get_route) { "/api/v1/product/#{ulid}" }
+
+      let(:product_response) do
+        {
+          _links: { href: "api/v1/product/#{ulid}" },
+          name: 'Old Gregg',
+          description: 'Locke Monster',
+          active: true
+        }
+      end
+
+      let(:listener) do
+        Class.new do
+          attr_accessor :product
+
+          def initialize(response)
+            @response = response
+          end
+
+          def on_product_requested(event)
+            product = @response.merge(id: event[:id])
+          end
+        end.new(product_response)
+      end
+
+      it 'returns a 200 response code' do
+        res = get product_get_route
+
+        _(res.status).must_equal 200
+      end
+
+      describe 'response serialization' do
+        it 'returns a HAL serialized JSON that represents a product' do
+          res = get product_get_route
+          contract = ProductResponseContract.new.call(JSON.parse(res.body))
+
+          _(contract.errors).must_be :empty?
+        end
+      end
+    end
+  end
+end

--- a/test/request/root_test.rb
+++ b/test/request/root_test.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 
 class RootTest < RequestTest
   describe '#GET' do
-    subject { app.get '/' }
+    subject { get '/' }
 
     it 'resolves with a success code' do
       _(subject.status).must_equal 200

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -14,7 +14,7 @@ Dir[File.join(__dir__, '..', 'publishers', '*.rb')].each { |file| require file }
 
 class RequestTest < Minitest::Spec
   def app
-    Rack::MockRequest.new(App.new)
+    @app ||= Rack::MockRequest.new(App.new)
   end
 end
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -11,7 +11,7 @@ require 'rack/mock'
 require 'rack/test'
 
 Dir[File.join(__dir__, '..', 'publishers', '*.rb')].each { |file| require file }
-Dir[File.join(__dir__, '..', 'events', '*.rb')].each { |file| require file }
+Dir[File.join(__dir__, '..', 'repositories', '*.rb')].each { |file| require file }
 Dir[File.join(__dir__, 'support', 'schemas', '*.rb')].each do |file|
   require file
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -8,13 +8,22 @@ require 'minitest/autorun'
 require 'minitest/spec'
 require 'mocha/minitest'
 require 'rack/mock'
+require 'rack/test'
 
-require_relative '../app'
 Dir[File.join(__dir__, '..', 'publishers', '*.rb')].each { |file| require file }
+Dir[File.join(__dir__, '..', 'events', '*.rb')].each { |file| require file }
+Dir[File.join(__dir__, 'support', 'schemas', '*.rb')].each do |file|
+  require file
+end
+
+APP_STACK =
+  Rack::Builder.parse_file(File.join(__dir__, '..', 'config.ru')).first
 
 class RequestTest < Minitest::Spec
+  include Rack::Test::Methods
+
   def app
-    @app ||= Rack::MockRequest.new(App.new)
+    APP_STACK
   end
 end
 

--- a/test/support/schemas/hal_base.rb
+++ b/test/support/schemas/hal_base.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# typed: false
+
+HalBase = Dry::Schema.Params do
+  required(:_links).hash do
+    required(:self).hash do
+      required(:href).value(:string)
+    end
+    optional(:next).hash do
+      required(:href).value(:string)
+    end
+    optional(:items).array(:hash) do
+      required(:href).value(:string)
+    end
+  end
+end

--- a/test/support/schemas/product_response_contract.rb
+++ b/test/support/schemas/product_response_contract.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: false
+
+
+class ProductResponseContract < Dry::Validation::Contract
+  json(HalBase) do
+    required(:name).value(:string)
+    required(:description).value(:string)
+    required(:active).value(:bool)
+  end
+end

--- a/test/unit/publishers/product_publisher_test.rb
+++ b/test/unit/publishers/product_publisher_test.rb
@@ -19,5 +19,17 @@ class ProductPublisherTest < UnitTest
 
       _(event_data).must_equal params
     end
+
+    it 'emits the product requested event' do
+      params = { id: '123ME' }
+      event_data = {}
+      subject.subscribe('product.requested') do |event|
+        event_data = event[:product]
+      end
+
+      subject.publish('product.requested', product: params)
+
+      _(event_data).must_equal params
+    end
   end
 end

--- a/test/unit/repositories/product_test.rb
+++ b/test/unit/repositories/product_test.rb
@@ -9,10 +9,17 @@ class ProductRepositoryTest < UnitTest
 
   describe '#get' do
     let(:product) do
-      { id: '123ME', name: 'Bilbo Baggins Bag-End', description: 'A Hovel' }
+      {
+        id: '123ME',
+        name: 'Bilbo Baggins Bag-End',
+        description: 'A Hovel',
+        active: true
+      }
     end
+    let(:links) { { _links: { self: { href: "/products/#{product[:id]}" } } } }
+
     it 'returns a single product resource using a unique identifier' do
-      _(subject.get(product[:id])).must_equal product
+      _(subject.get(product[:id])).must_equal product.merge(links)
     end
   end
 end

--- a/test/unit/repositories/product_test.rb
+++ b/test/unit/repositories/product_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# typed: ignore
+
+require_relative '../../spec_helper'
+
+class ProductRepositoryTest < UnitTest
+  subject { ::ProductRepository.new }
+
+  describe '#get' do
+    let(:product) do
+      { id: '123ME', name: 'Bilbo Baggins Bag-End', description: 'A Hovel' }
+    end
+    it 'returns a single product resource using a unique identifier' do
+      _(subject.get(product[:id])).must_equal product
+    end
+  end
+end


### PR DESCRIPTION
Work to define HAL specific JSON responses and params to PUT/PATCH and POST routes. This work will define reusable validations for both the routes (params) and the test suite (responses).